### PR TITLE
Ensure home background video autoplays and update fullpage initialization

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -56,7 +56,7 @@
 
 <div id="fullpage">
     <div class="section active" id="section0" style="padding-bottom: 0;">
-        <video class="home-mv-video" src="mov/codefornagoya.mov" poster="mov/codefornagoya.jpg" loop data-autoplay ></video>
+        <video class="home-mv-video" src="mov/codefornagoya.mov" poster="mov/codefornagoya.jpg" loop muted playsinline autoplay></video>
         <div class="home-mv-dot"></div>
         <div class="home-title">
             <img alt="title" src="imgs/title.png">

--- a/docs/index.js
+++ b/docs/index.js
@@ -10,33 +10,44 @@ $(document).ready(function() {
 	// 		return false;
 	// 	}
 	// }
-  
-	$('#fullpage').fullpage({
-		licenseKey: null,
+
+	const safePlay = function(videoElement) {
+		if (!videoElement) return;
+		videoElement.muted = true;
+		videoElement.playsInline = true;
+		const playPromise = videoElement.play();
+		if (playPromise && typeof playPromise.catch === 'function') {
+			playPromise.catch(function() {
+				// Ignore autoplay restrictions until user interacts.
+			});
+		}
+	};
+
+	new fullpage('#fullpage', {
+		licenseKey: 'OPEN-SOURCE-GPLV3-LICENSE',
 		sectionsColor: ['#000', '#f6ab00', '#7baabe', '#ccddff', '#4bbfc3'],
 		anchors: ['home', 'about', 'product', 'timeline', 'contact'],
 		menu: '#menu',
 		autoScrolling: false,
-		scrollHorizontally: true,
-		afterLoad: function(anchorLink, index) {
-			const loadedSection = $(this);
-			//using index
-			if (index == 1) {
+		scrollHorizontally: false,
+		afterLoad: function(origin, destination) {
+			if (destination && destination.index === 0) {
 				const video = document.querySelector('video');
-				video.play();
+				safePlay(video);
 			}
 		}
 	});
 
 	const video = document.querySelector('video');
-	video.addEventListener('loadeddata', function() {
-		video.play();
-	});
+	if (video) {
+		video.addEventListener('loadeddata', function() {
+			safePlay(video);
+		});
+	}
 
 	$.get('event.json')
 	//サーバーからの返信を受け取る
 	.done(function(ret) {
-		console.log(ret);
 		$('#history').html('');
 		for (data of ret) {
 			const html = `
@@ -44,13 +55,13 @@ $(document).ready(function() {
 				<div class="cd-timeline__img cd-timeline__img--movie">
 				<i class="font-white fa-solid fa-calendar-days"></i>
 				</div> <!-- cd-timeline__img -->
-	
+
 				<div class="cd-timeline__content text-component">
 				<h2>${data.title}</h2>
 				<p class="color-contrast-medium">
 					${data.content}
 				</p>
-				
+
 				<div class="flex justify-between items-center">
 					<span class="cd-timeline__date">${data.date}</span>
 					<a href="${data.url}" target="_blank" class="btn btn--subtle">Read more</a>
@@ -96,5 +107,5 @@ $(document).ready(function() {
 			$('#message').html('送信に失敗しました。');
 		});
 	});
-  
+
 });


### PR DESCRIPTION
### Motivation
- Fix unreliable autoplay of the home background video on modern browsers by explicitly muting and enabling inline playback and to make `play()` failures non-blocking. 
- Update usage of the fullPage library to the newer initialization pattern and supply an open-source license key while adjusting scrolling settings.

### Description
- Add `muted`, `playsinline`, and `autoplay` attributes to the `<video>` in `docs/index.html` and remove the older `data-autoplay` usage. 
- Introduce a `safePlay` helper in `docs/index.js` that sets `muted` and `playsInline` and calls `play()` while gracefully handling promise rejections. 
- Replace the old `$('#fullpage').fullpage({...})` initialization with `new fullpage('#fullpage', {...})`, set `licenseKey` to `'OPEN-SOURCE-GPLV3-LICENSE'`, and change `scrollHorizontally` to `false`. 
- Use the updated fullPage callback signature (`afterLoad` receiving `origin`/`destination`) to call `safePlay` when the home section becomes active, and also call `safePlay` on the video's `loadeddata` event; remove an unused `console.log` and tidy whitespace. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a043166b5ec8321885ca0439a84d08c)