### PR TITLE
Fix duplicate `video` const breaking homepage script

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -51,10 +51,10 @@ $(function () {
 		}
 	});
 
-	const video = document.querySelector('video');
-	if (video) {
-		video.addEventListener('loadeddata', function() {
-			safePlay(video);
+	const heroVideo = document.querySelector('video');
+	if (heroVideo) {
+		heroVideo.addEventListener('loadeddata', function() {
+			safePlay(heroVideo);
 		});
 	}
 


### PR DESCRIPTION
### Motivation
- A parse-time error from redeclaring `const video` caused the homepage script to fail and the layout/fullPage behavior to break after merge.

### Description
- Rename the second `const video` to `const heroVideo` in `docs/index.js` and update the attached event listener to use `heroVideo`.
- Preserve existing `afterLoad` logic and otherwise make a minimal change to restore script execution.

### Testing
- Ran `node --check docs/index.js` and the file parsed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04387e81b08321b0dcafc2af918ad5)