### PR TITLE
chore: upgrade fullPage.js to v4.0.41

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,7 @@
     <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/themes/smoothness/jquery-ui.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/siimple@3.0.0/dist/siimple.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/siimple-colors@0.2.0/dist/siimple-colors.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/fullPage.js/3.1.2/fullpage.min.css" integrity="sha512-4rPgyv5iG0PZw8E+oRdfN/Gq+yilzt9rQ8Yci2jJ15rAyBmF0HBE4wFjBkoB72cxBeg63uobaj1UcNt/scV93w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullpage.js@4.0.41/dist/fullpage.min.css" />
     <link rel="stylesheet" type="text/css" href="index.css" />
     <link rel="shortcut icon" href="icon.png">
 
@@ -37,7 +37,7 @@
     <script src="https://kit.fontawesome.com/e1d3e53513.js" crossorigin="anonymous"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/fullPage.js/3.1.2/fullpage.min.js" integrity="sha512-gSf3NCgs6wWEdztl1e6vUqtRP884ONnCNzCpomdoQ0xXsk06lrxJsR7jX5yM/qAGkPGsps+4bLV5IEjhOZX+gg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdn.jsdelivr.net/npm/fullpage.js@4.0.41/dist/fullpage.min.js"></script>
     <script src="vendors/vertical-timeline/assets/js/main.js"></script>
     <script type="text/javascript" src="index.js"></script>
 


### PR DESCRIPTION
### Motivation
- Update the bundled fullPage.js dependency to the v4 release so the site uses the newer build and fixes/changes included in v4 while keeping the current initialization approach (`new fullpage(...)`).

### Description
- Replaced the CSS and JS CDN references in `docs/index.html` to `https://cdn.jsdelivr.net/npm/fullpage.js@4.0.41/dist/fullpage.min.css` and `https://cdn.jsdelivr.net/npm/fullpage.js@4.0.41/dist/fullpage.min.js` respectively, without modifying existing initialization code.

### Testing
- No automated tests were run for this change (static dependency URL update only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0481087b4c832196d67b58d7706ea2)