### PR TITLE
Fix hero video sizing on mobile to avoid letterboxing

### DIFF
--- a/docs/index.css
+++ b/docs/index.css
@@ -268,10 +268,11 @@ p {
   position: fixed;
   left: 0;
   top: 0;
-  min-width: 100%;
-  min-height: 100%;
-  width: auto;
-  height: auto;
+  width: 100vw;
+  height: 100vh;
+  height: 100dvh;
+  object-fit: cover;
+  object-position: center center;
 }
 
 .home-mv-dot {

--- a/docs/index.scss
+++ b/docs/index.scss
@@ -319,10 +319,11 @@ p {
   position: fixed;
   left: 0;
   top: 0;
-  min-width: 100%;
-  min-height: 100%;
-  width: auto;
-  height: auto;
+  width: 100vw;
+  height: 100vh;
+  height: 100dvh;
+  object-fit: cover;
+  object-position: center center;
 }
 
 .home-mv-dot {


### PR DESCRIPTION
### Motivation
- Mobile browsers sometimes showed vertical blank space (letterboxing) around the hero `video` because the previous rules used `min-width/min-height` and `auto` sizing that didn't guarantee full viewport coverage.
- The change ensures the hero video always fills the viewport while preserving aspect ratio and keeping the subject centered.

### Description
- Replaced the `.home-mv-video` sizing from `min-width/min-height` + `auto` to viewport units with `width: 100vw; height: 100vh; height: 100dvh;` to improve mobile behavior.
- Added `object-fit: cover` and `object-position: center center` so the video fills both axes while maintaining aspect ratio and center-cropping when necessary.
- Applied the update to both source SCSS and the generated CSS in `docs/index.scss` and `docs/index.css`.

### Testing
- Ran `git diff -- docs/index.scss docs/index.css` to confirm the expected changes were produced, which succeeded.
- Committed the changes with `git add docs/index.scss docs/index.css && git commit -m "Fix mobile hero video to fill viewport without blank space"`, which succeeded.
- Verified file contents with `nl -ba docs/index.scss | sed -n '315,335p'; nl -ba docs/index.css | sed -n '264,285p'`, which showed the new viewport and `object-fit` rules and succeeded.
- Created the PR metadata via the local `make_pr` step, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04fa61414c8321989d58bcc1e79f51)