### PR TITLE
Update README to reflect current GitHub Pages + fullPage.js workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,72 @@
 # code4.nagoya
 
-このリポジトリは https://code4.nagoya のホスティングのためのリポジトリです。
+このリポジトリは、`https://code4.nagoya`（および `https://www.code4.nagoya`）で公開している Web サイトのソース管理用です。
+公開先は GitHub Pages です。
 
-GitHub Pagesを使用し、カスタムドメインとして「code4.nagoya 」を設定しています。
+## 現在の構成
 
-## HTTPS対応
+- 配信ディレクトリ: `docs/`
+- トップページ: `docs/index.html`
+- スタイル: `docs/index.scss`（ビルド済みCSSは `docs/index.css`）
+- スクリプト: `docs/index.js`
+- データファイル:
+  - `docs/production.json`（プロダクト一覧）
+  - `docs/event.json`（イベント / タイムライン）
 
-現在はさくらインターネットのVPS上のnginxでHTTPSを処理してリバースプロキシでGitHub Pagesを読み込んでいます。
+トップページは **fullPage.js** ベースの構成になっており、`index.js` で JSON を読み込んで画面を組み立てます。
 
-よって、ブラウザはhttps://code4.nagoya にアクセスすると、さくらのVPSと通信しています。さくらのVPSはGitHub Pagesと通信しコンテンツを読み込み返します。
+## HTTPS / ドメイン
 
-## コンテンツの編集について
+現在は GitHub Pages のカスタムドメイン設定で公開しています。
+HTTPS は GitHub Pages 側の証明書機能（Enforce HTTPS）を利用する前提です。
 
-例えば以下のコンテツはMobiriseというツールを使って更新しています。
+- CNAME 設定ファイル: `docs/CNAME`
+- Google Search Console 用ファイル: `docs/googleb85580e68597c4f2.html`
 
-https://code4.nagoya/event/2017/11/opendata/
+> 以前の「VPS + nginx リバースプロキシ」前提の説明は現在の運用とは一致しません。
 
-Mobiriseについて
-https://mobirise.com/ja/
+## 更新方法（通常）
 
-上記コンテンツを編集する場合はMobiriseを利用して下さい。
+通常の更新は `docs/` 配下のファイル編集と GitHub への push で行います。
 
-1. GitHubからローカルにcloneする。(詳細省きます)
-2. project.mobiriseをMobiriseを開く
-3. Mobirise上で編集する
-4. Mobirise上でローカルリポジトリにPublishする
-5. ローカルからGithubにPushする
+1. このリポジトリを clone
+2. 必要なファイルを編集（主に `docs/`）
+3. 変更を commit
+4. GitHub に push
+5. GitHub Pages の反映を確認
+
+## JSON ベースでの更新
+
+### 1) プロダクト一覧を更新する
+
+`docs/production.json` の配列要素を編集します。各要素は以下のキーを使います。
+
+- `title`: プロダクト名
+- `description`: 説明文
+- `url`: 遷移先 URL
+- `icon`: サムネイル画像パス
+- `background`: 背景画像パス
+
+### 2) タイムライン（イベント）を更新する
+
+`docs/event.json` の配列要素を編集します。各要素は以下のキーを使います。
+
+- `title`: タイトル
+- `content`: 本文
+- `date`: 日付表示文字列
+- `url`: 詳細ページ URL
+
+### 3) 画像を追加・差し替えする
+
+画像は主に `docs/imgs/` 配下に配置し、JSON から相対パスで参照します。
+
+## Mobirise コンテンツについて
+
+`docs/event/` や `docs/udc/` 配下には、過去イベント向けに Mobirise 由来のコンテンツが含まれています。
+該当コンテンツを再編集する場合は、必要に応じて各ディレクトリ内の `project.mobirise` を利用してください。
 
 ## License
 
-These codes are licensed under CC0.
+This repository is licensed under CC0.
 
 [![CC0](http://i.creativecommons.org/p/zero/1.0/88x31.png "CC0")](http://creativecommons.org/publicdomain/zero/1.0/deed.ja)


### PR DESCRIPTION
### Motivation

- Align documentation with the repository's actual architecture which now serves the site from GitHub Pages using the `docs/` directory and a `fullPage.js`-based front-end.
- Remove the outdated VPS/nginx reverse-proxy HTTPS explanation and document the current GitHub Pages custom domain + Enforce HTTPS assumption.
- Explain the JSON-driven content workflow so editors can update products and events via `docs/production.json` and `docs/event.json`.

### Description

- Rewrote `README.md` to describe the current distribution directory (`docs/`), entry points (`docs/index.html`, `docs/index.js`), and styling (`docs/index.scss` / `docs/index.css`).
- Replaced the old HTTPS section with a GitHub Pages custom domain explanation and referenced `docs/CNAME` and the Search Console token `docs/googleb85580e68597c4f2.html`.
- Added explicit JSON-editing instructions and field definitions for `docs/production.json` (products) and `docs/event.json` (timeline/events), and documented image placement under `docs/imgs/`.
- Clarified that historical Mobirise-generated content remains under `docs/event/` and `docs/udc/` and when to use the included `project.mobirise` files.

### Testing

- Performed repository sanity checks after the update and verified the working tree contains the updated `README.md` file.
- Created the PR using the project's PR tooling and the PR creation step completed successfully.
- No automated unit or CI tests apply to this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05036467d48321a717fb8dd2df69ba)