### PR TITLE
Add mobile menu toggle with responsive styles and JS behavior

### DIFF
--- a/docs/index.css
+++ b/docs/index.css
@@ -141,6 +141,10 @@ p {
   color: #fff;
 }
 
+#menu-toggle {
+  display: none;
+}
+
 .twitter-share-button {
   position: fixed;
   z-index: 99;
@@ -382,3 +386,53 @@ p {
 .fluid-width {
   width: 95%;
 }/*# sourceMappingURL=index.css.map */
+
+@media (max-width: 767px) {
+  #menu-toggle {
+    display: block;
+    position: fixed;
+    top: 10px;
+    left: 10px;
+    z-index: 80;
+    width: 44px;
+    height: 44px;
+    border: none;
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.9);
+    color: #000;
+    font-size: 26px;
+    line-height: 1;
+  }
+
+  #menu {
+    display: none;
+    top: 60px;
+    left: 10px;
+    right: 10px;
+    width: auto;
+    height: auto;
+    padding: 8px;
+    box-sizing: border-box;
+    background: rgba(0, 0, 0, 0.8);
+    border-radius: 12px;
+  }
+
+  #menu.is-open {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+  }
+
+  #menu li {
+    margin: 6px;
+  }
+
+  #menu li a,
+  #menu li.active a {
+    padding: 8px 16px;
+    font-size: 14px;
+    line-height: 1.2;
+    white-space: nowrap;
+  }
+}

--- a/docs/index.css
+++ b/docs/index.css
@@ -393,7 +393,7 @@ p {
     position: fixed;
     top: 10px;
     left: 10px;
-    z-index: 80;
+    z-index: 1001;
     width: 44px;
     height: 44px;
     border: none;
@@ -406,6 +406,7 @@ p {
 
   #menu {
     display: none;
+    z-index: 1000;
     top: 60px;
     left: 10px;
     right: 10px;

--- a/docs/index.html
+++ b/docs/index.html
@@ -44,6 +44,8 @@
 </head>
 <body>
 
+<button id="menu-toggle" type="button" aria-expanded="false" aria-controls="menu" aria-label="メニューを開く">☰</button>
+
 <ul id="menu">
     <li data-menuanchor="home" class="active"><a href="#home">Home</a></li>
     <li data-menuanchor="about"><a href="#about">About</a></li>

--- a/docs/index.js
+++ b/docs/index.js
@@ -71,6 +71,24 @@ $(function () {
     $(".fp-tableCell").css("height", "");
   });
 
+
+
+  const menuToggle = $("#menu-toggle");
+  const menu = $("#menu");
+
+  menuToggle.on("click", function () {
+    const isOpen = menu.hasClass("is-open");
+    menu.toggleClass("is-open", !isOpen);
+    menuToggle.attr("aria-expanded", (!isOpen).toString());
+  });
+
+  menu.find("a").on("click", function () {
+    if (window.matchMedia("(max-width: 767px)").matches) {
+      menu.removeClass("is-open");
+      menuToggle.attr("aria-expanded", "false");
+    }
+  });
+
   // Form submission with error handling
   $("form").submit(function (event) {
     event.preventDefault();

--- a/docs/index.scss
+++ b/docs/index.scss
@@ -448,7 +448,7 @@ p {
     position: fixed;
     top: 10px;
     left: 10px;
-    z-index: 80;
+    z-index: 1001;
     width: 44px;
     height: 44px;
     border: none;
@@ -461,6 +461,7 @@ p {
 
   #menu {
     display: none;
+    z-index: 1000;
     top: 60px;
     left: 10px;
     right: 10px;

--- a/docs/index.scss
+++ b/docs/index.scss
@@ -156,6 +156,10 @@ p {
   margin: 0;
 }
 
+#menu-toggle {
+  display: none;
+}
+
 .twitter-share-button {
   position: fixed;
   z-index: 99;
@@ -436,4 +440,54 @@ p {
 
 .fluid-width {
   width: 95%;
+}
+
+@media (max-width: 767px) {
+  #menu-toggle {
+    display: block;
+    position: fixed;
+    top: 10px;
+    left: 10px;
+    z-index: 80;
+    width: 44px;
+    height: 44px;
+    border: none;
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.9);
+    color: #000;
+    font-size: 26px;
+    line-height: 1;
+  }
+
+  #menu {
+    display: none;
+    top: 60px;
+    left: 10px;
+    right: 10px;
+    width: auto;
+    height: auto;
+    padding: 8px;
+    box-sizing: border-box;
+    background: rgba(0, 0, 0, 0.8);
+    border-radius: 12px;
+  }
+
+  #menu.is-open {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+  }
+
+  #menu li {
+    margin: 6px;
+  }
+
+  #menu li a,
+  #menu li.active a {
+    padding: 8px 16px;
+    font-size: 14px;
+    line-height: 1.2;
+    white-space: nowrap;
+  }
 }


### PR DESCRIPTION
### Motivation

- Improve usability on small screens by providing a toggleable menu for mobile devices and prevent the desktop menu from always showing on narrow viewports.

### Description

- Added a menu toggle button to `index.html` with appropriate ARIA attributes (`id="menu-toggle"`, `aria-expanded`, `aria-controls`, and an accessible label). 
- Implemented toggle behavior in `index.js` that toggles an `is-open` class on `#menu`, updates `aria-expanded`, and closes the menu when a menu link is clicked on small screens. 
- Added responsive CSS/SCSS rules in `index.css` and `index.scss` under an `@media (max-width: 767px)` query to hide the menu by default on mobile, style the toggle button, define the mobile menu layout, and adjust menu item spacing and sizing. 
- Preserved existing desktop styles and fullpage initialization in `index.js` while introducing the mobile-specific UI enhancements.

### Testing

- No automated tests were present or run for these UI changes in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a051efdba348321a02e0d1bb09cc635)